### PR TITLE
chore(version-rc): remove rc tags

### DIFF
--- a/packages/footer/package.json
+++ b/packages/footer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-dummy-js-versioning-playground/footer",
-  "version": "12.0.0-rc.0",
+  "version": "12.0.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@my-dummy-js-versioning-playground/header",
-  "version": "12.0.0-rc.0",
+  "version": "12.0.0",
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This PR automatically removes “rc” prerelease tags after a release merge.